### PR TITLE
Change ToggleCamState to be compatible with my Slo-Mo Mod

### DIFF
--- a/Config/ControllerSettings.cs
+++ b/Config/ControllerSettings.cs
@@ -44,7 +44,7 @@ internal class ControllerSettings : ModSettingsCategory
          "* false: stick up => look up, stick down => look down\n" +
          "* true : stick up => look down, stick down => look up");
 
-      _toggleCamStateButton = CreateEntry("ToggleCamState", ControllerButton.LB,
+      _toggleCamStateButton = CreateEntry("ToggleCamState", ControllerButton.LStick,
             "Tells which button to use to toggle between the alternative camera mode and the original camera mode\n" + 
             "Controller: None (disable), X, Y, LB, RB, LStick, RStick");
       _snapAlignCamButton = CreateEntry("SnapAlignCam", ControllerButton.RStick,

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The keys are presets and can be customized. Controller inputs are fixed.
 | Original camera (isometric)             | 1                         | -                           |
 | Alternative camera: Third Person        | 2                         | -                           |
 | Alternative camera: First Person        | 3                         | -                           |
-| Toggle camera: Original <-> Alternative | Tab                       | Left Bumper *)              |
+| Toggle camera: Original <-> Alternative | Tab                       | Left Stick *)               |
 | Toggle camera auto-align mode           | 5                         | -                           |
 | Toggle invert look horizontal           | 6                         | -                           |
 | Toggle Game HUD                         | H                         | -                           |


### PR DESCRIPTION
I was running out of keybinds to use for toggling time scales. If this switches then I can use LB to toggle fast forward, and RB to toggle slo-mo (don't need to switch that because it has a *hold* function). The reason I didn't assign the fast forward to left stick click is because in photo mode, left stick click has a button mapping already.